### PR TITLE
Update kbutils.py

### DIFF
--- a/pyniexp/kbutils.py
+++ b/pyniexp/kbutils.py
@@ -4,9 +4,12 @@ try:
     import keyboard
 except ImportError:
     print('module "keyboard" is not installed')
-    raise(ImportError)
+    raise ImportError
 
-kbLayout = [k[0] for k in keyboard._os_keyboard.official_virtual_keys.values()]
+kbLayout = []
+if hasattr(keyboard._os_keyboard, 'official_virtual_keys'):
+    kbLayout = [k[0] for k in keyboard._os_keyboard.official_virtual_keys.values()]
+
 
 class Key:
     name = ''

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=['pyniexp'],
     install_requires=['keyboard','nidaqmx','loguru','matplotlib'],
     
-    version='0.22.4',
+    version='0.22.5',
     license='GPL-3.0',
     description='Python interface for neuroimaging experiments',
     


### PR DESCRIPTION
Protect against not having official_virtual_keys property for some keyboards (._nixkeyboard)

This is needed to solve an error which is produced when trying to test https://github.com/daniellekurtin/task_switching_paradigm using continuous integration.